### PR TITLE
Use tini as container init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-slim
 
-RUN apt-get update && apt-get install -y git curl procps python3 make g++ cron && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git curl procps python3 make g++ cron tini && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -14,4 +14,5 @@ RUN mkdir -p /data
 
 EXPOSE 3000
 
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["alphaclaw", "start"]


### PR DESCRIPTION
This runs OpenClaw under tini so the container has a real PID 1 reaper.\n\nWhy:\n- Railway/OpenClaw cron and subprocess workflows can leave orphaned child processes.\n- With node as PID 1, adopted children can remain as defunct zombies.\n- tini is the standard minimal init for containers and forwards signals while reaping children.\n\nChange:\n- Install Debian tini in the image.\n- Use ENTRYPOINT ["/usr/bin/tini", "--"] before the existing alphaclaw start CMD.\n\nVerified on Railway by deploying the same Dockerfile shape: PID 1 became /usr/bin/tini -- alphaclaw start, healthcheck stayed healthy, and no zombie processes were present after post-deploy smoke checks.