### PR TITLE
Install GitHub CLI in image so agents can create PRs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,16 @@ FROM node:22-slim
 
 RUN apt-get update && apt-get install -y git curl procps python3 make g++ cron && rm -rf /var/lib/apt/lists/*
 
+# Install GitHub CLI so the agent can run `gh pr create` etc.
+# `gh` auto-uses $GH_TOKEN / $GITHUB_TOKEN from env, so no auth step is required at runtime.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update && apt-get install -y gh \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Summary

- Add the official GitHub CLI (`gh`) apt repo and install `gh` in the image.

## Why

When openclaw runs in this image and a user asks the agent to create a pull request, the agent answers with something like:

> I couldn't create the GitHub PR objects from this container because there's no gh CLI and no GitHub API token configured here.

Diagnosis on a live Railway deployment confirmed:

1. `which gh` → not installed (the existing `apt-get install` line installs `git curl procps python3 make g++ cron` but not `gh`).
2. `GH_TOKEN` and `GITHUB_TOKEN` set via the AlphaClaw Envars UI **are** present in the agent's shell.

So tooling is the only gap. With `gh` installed, the agent can run `gh pr create` directly. `gh` auto-uses `$GH_TOKEN` / `$GITHUB_TOKEN` at runtime, so no `gh auth login` step is required and no new env vars are introduced.

A pure-curl workaround works (`curl … /repos/<owner>/<repo>/pulls`), but most agents reach for `gh` first, so installing it removes a confusing failure mode that affects every user of this template.

## Test plan

- [ ] Build the image locally: `docker build -t openclaw-rw .`
- [ ] Run interactively and verify: `docker run --rm openclaw-rw gh --version`
- [ ] Deploy to Railway with `GH_TOKEN` set; ask the agent to create a PR and confirm `gh pr create` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)