### PR TITLE
Install Playwright Chromium runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM node:22.22.3-slim
 
-RUN apt-get update && apt-get install -y git curl procps python3 make g++ cron tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates git curl procps python3 make g++ cron tini \
+    xvfb fonts-noto-color-emoji fonts-unifont libfontconfig1 libfreetype6 \
+    xfonts-scalable fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei \
+    fonts-tlwg-loma-otf fonts-freefont-ttf \
+    libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libcairo2 \
+    libcups2 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0 libnspr4 libnss3 \
+    libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 \
+    libxfixes3 libxkbcommon0 libxrandr2 \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
Adds the Debian 12 runtime libraries required by Playwright's Chromium build and explicitly keeps ca-certificates when using --no-install-recommends.

Without these packages, Chromium fails at launch on Railway because libglib-2.0.so.0 is missing. Without the explicit CA bundle, outbound HTTPS requests also fail.

Verified on a fresh Railway Dockerfile deployment:
- health endpoint returns 200
- tini runs as PID 1
- Telegram's live probe is healthy
- Playwright launches Chromium and executes the browser suite
- OpenAI gpt-5.6-sol completes without fallback