### PR TITLE
Coordinate Node 26 runtime for OpenClaw 2026.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.3-slim
+FROM node:26.1.0-slim
 
 RUN apt-get update && apt-get install -y git curl procps python3 make g++ cron tini && rm -rf /var/lib/apt/lists/*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@chrysb/alphaclaw": "0.9.34"
       },
       "engines": {
-        "node": ">=22.22.3 <23"
+        "node": ">=26.1.0"
       }
     },
     "node_modules/@chrysb/alphaclaw": {
@@ -997,6 +997,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1962,6 +1963,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2342,6 +2344,7 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.44.0.tgz",
       "integrity": "sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.28.0",
         "abort-controller": "^3.0.0",
@@ -2410,6 +2413,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4019,6 +4023,7 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
       "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22.19.0"
       }
@@ -4233,6 +4238,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "@chrysb/alphaclaw": "0.9.34"
   },
   "engines": {
-    "node": ">=22.22.3 <23"
+    "node": ">=26.1.0"
   }
 }


### PR DESCRIPTION
Updates the deployment image and package engine to Node 26.1, the minimum supported Node 26 runtime for OpenClaw 2026.9.3. Coordinates with chrysb/alphaclaw#126; the AlphaClaw package pin remains unchanged until that release is published.